### PR TITLE
update circleci image to cimg

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ references:
   #
   default_container_config: &default_container_config
     docker:
-      - image: circleci/node:14
+      - image: cimg/node:14.18.3
 
   workspace_root: &workspace_root ~/project
 


### PR DESCRIPTION
## Why?

-   circleci docker images have been depreciated

## What?

-  Use `cimg` instead with will node version

### Anything in particular you'd like to highlight to reviewers?

Circleci is failing on snyk vulnerabilities - are we ok leaving this until the next round of tech debt?
