### PR TITLE
Andy/ei 4856 export markdown to plain text function

### DIFF
--- a/lib/MarkdownPages.js
+++ b/lib/MarkdownPages.js
@@ -10,6 +10,7 @@ const { createDatabase } = require('./createDatabase');
 const { getPageData } = require('./getPageData');
 const { pageHandler } = require('./handlers/pageHandler');
 const { imageHandler } = require('./handlers/imageHandler');
+const { markdownToText } = require('./convertMarkdown');
 
 /**
  * @type {Options}
@@ -142,6 +143,16 @@ class MarkdownPages {
 		}
 
 		throw new TypeError('A valid page was not provided');
+	}
+
+	/**
+	 * Markdown to text
+	 * @param {String} content
+	 * @param {import('marked').MarkedOptions} markedOptions
+	 * @returns {String}
+	 */
+	markdownToText(content, options = this.options) {
+		return markdownToText(content, options);
 	}
 }
 

--- a/lib/MarkdownPages.js
+++ b/lib/MarkdownPages.js
@@ -10,7 +10,6 @@ const { createDatabase } = require('./createDatabase');
 const { getPageData } = require('./getPageData');
 const { pageHandler } = require('./handlers/pageHandler');
 const { imageHandler } = require('./handlers/imageHandler');
-const { markdownToText } = require('./convertMarkdown');
 
 /**
  * @type {Options}
@@ -143,16 +142,6 @@ class MarkdownPages {
 		}
 
 		throw new TypeError('A valid page was not provided');
-	}
-
-	/**
-	 * Markdown to text
-	 * @param {String} content
-	 * @param {import('marked').MarkedOptions} markedOptions
-	 * @returns {String}
-	 */
-	markdownToText(content, options = this.options) {
-		return markdownToText(content, options);
 	}
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,4 @@
 const MarkdownPages = require('./MarkdownPages');
+const { markdownToText } = require('./convertMarkdown');
 
-module.exports = { MarkdownPages };
+module.exports = { MarkdownPages, markdownToText };

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "throat": "^6.0.0"
       },
       "devDependencies": {
-        "@financial-times/rel-engage": "^8.0.9",
+        "@financial-times/rel-engage": "^8.0.10",
         "@types/express": "^4.17.10",
         "@types/jest": "^29.5.5",
         "@types/lokijs": "^1.5.4",
@@ -703,9 +703,9 @@
       "dev": true
     },
     "node_modules/@financial-times/rel-engage": {
-      "version": "8.0.9",
-      "resolved": "https://registry.npmjs.org/@financial-times/rel-engage/-/rel-engage-8.0.9.tgz",
-      "integrity": "sha512-NGSK1cnqczlMIEQvZaZs8hoQ8SHBBYe0Nc9Xur6LJjM+0PTJmMO2mra/TMIYj1sXuHhk+8pyo3+sEDurYi5wFQ==",
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/@financial-times/rel-engage/-/rel-engage-8.0.10.tgz",
+      "integrity": "sha512-EMwy088nUGiG0BojOSrOfE+wfQ2pzHUh6ntVjMBl/uCI7dPRkMFF+/QX33Nhaxc4WitWILNe8uyUF5wdmwApdQ==",
       "dev": true,
       "dependencies": {
         "@financial-times/secret-squirrel": "^2.13.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/Financial-Times/express-markdown-pages",
   "devDependencies": {
-    "@financial-times/rel-engage": "^8.0.9",
+    "@financial-times/rel-engage": "^8.0.10",
     "@types/express": "^4.17.10",
     "@types/jest": "^29.5.5",
     "@types/lokijs": "^1.5.4",


### PR DESCRIPTION
## Why?

-   we want to convert markdown to plain text when indexing opensearch documents

## What?

-   export text-to-markdown function to be used independently of the markdown middleware

