### PR TITLE
Tech debt July 2025

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*  @financial-times/reliability-engineering
+*  @financial-times/engineering-insights

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "just-zip-it": "^3.2.0",
         "lokijs": "^1.5.12",
         "marked": "^4.3.0",
-        "nanoid": "^3.3.6",
+        "nanoid": "^3.3.8",
         "pluralize": "^8.0.0",
         "proper-url-join": "^2.1.0",
         "qs": "^6.10.0",
@@ -7636,9 +7636,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "just-zip-it": "^3.2.0",
     "lokijs": "^1.5.12",
     "marked": "^4.3.0",
-    "nanoid": "^3.3.6",
+    "nanoid": "^3.3.8",
     "pluralize": "^8.0.0",
     "proper-url-join": "^2.1.0",
     "qs": "^6.10.0",

--- a/package.json
+++ b/package.json
@@ -2,13 +2,13 @@
   "name": "@financial-times/express-markdown-pages",
   "version": "0.0.0",
   "description": "An Express middleware that transforms plain text files into dynamic pages and fits right into your existing app.",
+  "author": "Engineering Insights <engineering.insights@ft.com>",
   "main": "lib/index.js",
   "scripts": {
     "lint": "make verify",
     "test": "make test"
   },
   "keywords": [],
-  "author": "",
   "license": "ISC",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Why?

As part of tech debt week we are:
-   Removing rel-eng references
-   Upgrading serverless to v4
-   Upgrading AWS sdk to v3
-   Removing slack channel notifications

## What?

-   Removes rel-eng references
-   Upgrades nanoid to non-vulnerable version (https://www.mend.io/vulnerability-database/CVE-2024-55565)

### Anything in particular you'd like to highlight to reviewers?

Have I missed anything?
